### PR TITLE
Visitor can view articles by categories

### DIFF
--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,0 +1,5 @@
+class Api::CategoriesController < ApplicationController
+  def show
+    
+  end
+end

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,5 +1,6 @@
 class Api::CategoriesController < ApplicationController
   def show
-    
+    catefory = Category.find_cy(label: params["id"])
+    render json: {category: {lable: category.label, articles: category.articles}}
   end
 end

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,6 +1,6 @@
 class Api::CategoriesController < ApplicationController
   def show
-    catefory = Category.find_cy(label: params["id"])
+    category = Category.find_by(label: params["id"])
     render json: {category: {lable: category.label, articles: category.articles}}
   end
 end

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,6 +1,6 @@
 class Api::CategoriesController < ApplicationController
   def show
     category = Category.find_by(label: params["id"])
-    render json: {category: {lable: category.label, articles: category.articles}}
+    render json: {category: {label: category.label, articles: category.articles}}
   end
 end

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,6 +1,8 @@
 class Api::CategoriesController < ApplicationController
   def show
-    category = Category.find_by(label: params["id"])
-    render json: {category: {label: category.label, articles: category.articles}}
+    category = Category.find_by(label: params['id'])
+    render json: category, serializer: CategoriesShowSerializer
+  rescue StandardError => e
+    render json: { message: 'Something went wrong, this category was not found' }, status: 404
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :lead, :body
+  belongs_to :category
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  validates_presence_of :label
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
   validates_presence_of :label
+  has_many :articles
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,5 @@
 class Category < ApplicationRecord
   validates_presence_of :label
   has_many :articles
+  enum label: [:global_politics, :sports, :self_care, :news, :culture]
 end

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -4,4 +4,4 @@ class ArticlesIndexSerializer < ActiveModel::Serializer
   def created
     object.created_at.strftime('%F')
   end
-end
+end 

--- a/app/serializers/categories_show_serializer.rb
+++ b/app/serializers/categories_show_serializer.rb
@@ -1,0 +1,4 @@
+class CategoriesShowSerializer < ActiveModel::Serializer
+  attributes :id, :label
+  has_many :articles, serializer: ArticlesShowSerializer
+end

--- a/app/serializers/categories_show_serializer.rb
+++ b/app/serializers/categories_show_serializer.rb
@@ -1,4 +1,4 @@
 class CategoriesShowSerializer < ActiveModel::Serializer
   attributes :id, :label
-  has_many :articles, serializer: ArticlesShowSerializer
+  has_many :articles, serializer: ArticlesIndexSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get 'api/categories'
  namespace :api do
    resources :articles, only: [:index, :show]
-   resources :categories, only: [:index]
+   resources :categories, only: [:show]
  end
   
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
  namespace :api do
    resources :articles, only: [:index, :show]
+   resources :categories, only: [:index]
  end
   
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  namespace :api do
+    get 'categories/show'
+  end
+  get 'api/categories'
  namespace :api do
    resources :articles, only: [:index, :show]
    resources :categories, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
-    get 'categories/show'
+    resources :articles, only: %i[index show]
+    resources :categories, only: [:show]
   end
-  get 'api/categories'
- namespace :api do
-   resources :articles, only: [:index, :show]
-   resources :categories, only: [:show]
- end
-  
 end

--- a/db/migrate/20210105182921_create_categories.rb
+++ b/db/migrate/20210105182921_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :categories do |t|
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210105192224_add_association_to_article.rb
+++ b/db/migrate/20210105192224_add_association_to_article.rb
@@ -1,0 +1,7 @@
+class AddAssociationToArticle < ActiveRecord::Migration[6.0]
+  def change
+    change_table :articles do |t|
+      t.belongs_to :category, null: false, foreign_key: true
+  end
+end
+end 

--- a/db/migrate/20210105192224_add_association_to_article.rb
+++ b/db/migrate/20210105192224_add_association_to_article.rb
@@ -1,7 +1,7 @@
 class AddAssociationToArticle < ActiveRecord::Migration[6.0]
   def change
     change_table :articles do |t|
-      t.belongs_to :category, null: false, foreign_key: true
+    t.belongs_to :category, null: false, foreign_key: true
+    end
   end
 end
-end 

--- a/db/migrate/20210106144737_change_label_to_be_integer_in_categories.rb
+++ b/db/migrate/20210106144737_change_label_to_be_integer_in_categories.rb
@@ -1,0 +1,5 @@
+class ChangeLabelToBeIntegerInCategories < ActiveRecord::Migration[6.0]
+  def change
+    change_column :categories, :label, :integer, using: 'label::integer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_182921) do
+ActiveRecord::Schema.define(version: 2021_01_05_192224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2021_01_05_182921) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
+    t.bigint "category_id", null: false
+    t.index ["category_id"], name: "index_articles_on_category_id"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -29,4 +31,5 @@ ActiveRecord::Schema.define(version: 2021_01_05_182921) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "articles", "categories"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_153309) do
+ActiveRecord::Schema.define(version: 2021_01_05_182921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,12 @@ ActiveRecord::Schema.define(version: 2020_12_10_153309) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "label"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_192224) do
+ActiveRecord::Schema.define(version: 2021_01_06_144737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_192224) do
   end
 
   create_table "categories", force: :cascade do |t|
-    t.string "label"
+    t.integer "label"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "MyTitle" }
     lead { "MyLead" }
     body { "MyBody" }
+    association :category
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    
+    label { "MyLabel" }
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    label { "MyLabel" }
+    label {'global_politics'}
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe Category, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Category, type: :model do
   end
 
   describe 'is expected to have validation' do
-    it { is_expected.to validates_presence_of :label }
+    it { is_expected.to validate_presence_of :label }
   end
 
   describe 'is expected to have many products' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,3 +1,19 @@
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'is expected to have db colums' do
+    it { is_expected.to have_db_column :label }
+  end
+
+  describe 'is expected to have validation' do
+    it { is_expected.to validates_presence_of :label }
+  end
+
+  describe 'is expected to have many products' do
+    it { is_expected.to have_many(:articles) }
+  end
+
+  describe 'Factory' do
+    it 'is expected to be valid' do
+      expect(create(:category)).to be_valid
+    end
+  end
 end

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'GET/api/articles' do
+RSpec.describe 'GET/api/categories' do
   let!(:category) { create(:category, label: 'global_politics') }
   let!(:articles) { 2.times { create(:article, category: category) } }
 

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe 'GET/api/articles' do
-  let!(:category) { create(:category, name: 'global politics') }
+  let!(:category) { create(:category, label: 'global politics') }
   let!(:articles) { 2.times { create(:article, category: category) } }
 
   describe 'successfully get articles sorted in categories' do
     before do
-      get "/api/categories/#{category.name}"
+      get "/api/categories/#{category.label}"
     end
 
     it 'is expected to return a 200 response' do
@@ -15,12 +15,12 @@ RSpec.describe 'GET/api/articles' do
       expect(response_json['category']['articles'].count).to eq 2
     end
 
-    it 'it expected to return the name of the category' do
-      expect(response_json['category']['name']).to eq 'global politics'
+    it 'it expected to return the label of the category' do
+      expect(response_json['category']['label']).to eq 'global politics'
     end
 
     it 'is expected to show title of one of the articles' do
-      expect(response_json['category']['articles'][1]['name']).to eq 'MyTitle'
+      expect(response_json['category']['articles'][1]['title']).to eq 'MyTitle'
     end
   end
 end

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'GET/api/articles' do
+  let!(:category) { create(:category, name: 'global politics') }
+  let!(:articles) { 2.times { create(:article, category: category) } }
+
+  describe 'successfully get articles sorted in categories' do
+    before do
+      get "/api/categories/#{category.name}"
+    end
+
+    it 'is expected to return a 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return all categories' do
+      expect(response_json['category']['articles'].count).to eq 2
+    end
+
+    it 'it expected to return the name of the category' do
+      expect(response_json['category']['name']).to eq 'global politics'
+    end
+
+    it 'is expected to show title of one of the articles' do
+      expect(response_json['category']['articles'][1]['name']).to eq 'MyTitle'
+    end
+  end
+end

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'GET/api/categories' do
   let!(:category) { create(:category, label: 'global_politics') }
   let!(:articles) { 2.times { create(:article, category: category) } }
 
-  describe 'successfully get articles sorted in categories' do
+  describe 'successfully get articles sorted into categories' do
     before do
       get "/api/categories/#{category.label}"
     end
@@ -12,15 +12,28 @@ RSpec.describe 'GET/api/categories' do
     end
 
     it 'is expected to return all categories' do
-      expect(response_json['category']['articles'].count).to eq 2
+      expect(response_json['category'].count).to eq 3
     end
 
     it 'it expected to return the label of the category' do
       expect(response_json['category']['label']).to eq 'global_politics'
     end
 
-    it 'is expected to show title of one of the articles' do
+    it 'is expected to show title of ONE of the articles' do
       expect(response_json['category']['articles'][1]['title']).to eq 'MyTitle'
+    end
+    describe 'unsuccessfully get a specific category' do
+      before do
+        get '/api/categories/abc'
+      end
+
+      it 'expected to return a 404 response' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'is expected to respond with a error message' do
+        expect(response_json['message']).to eq 'Something went wrong, this category was not found'
+      end
     end
   end
 end

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe 'GET/api/categories' do
       expect(response).to have_http_status 200
     end
 
-    it 'is expected to return all categories' do
-      expect(response_json['category'].count).to eq 3
+    it 'is expected to return all articles in that category' do
+      expect(response_json['category']['articles'].count).to eq 2
     end
 
     it 'it expected to return the label of the category' do
@@ -22,6 +22,7 @@ RSpec.describe 'GET/api/categories' do
     it 'is expected to show title of ONE of the articles' do
       expect(response_json['category']['articles'][1]['title']).to eq 'MyTitle'
     end
+    
     describe 'unsuccessfully get a specific category' do
       before do
         get '/api/categories/abc'

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'GET/api/articles' do
-  let!(:category) { create(:category, label: 'global politics') }
+  let!(:category) { create(:category, label: 'global_politics') }
   let!(:articles) { 2.times { create(:article, category: category) } }
 
   describe 'successfully get articles sorted in categories' do
@@ -16,7 +16,7 @@ RSpec.describe 'GET/api/articles' do
     end
 
     it 'it expected to return the label of the category' do
-      expect(response_json['category']['label']).to eq 'global politics'
+      expect(response_json['category']['label']).to eq 'global_politics'
     end
 
     it 'is expected to show title of one of the articles' do


### PR DESCRIPTION
[Visitor can view articles by categories](https://www.pivotaltracker.com/story/show/176031775)
### User Story
```
As an API
In order to allow the client to categorise 
I would like the articles in the database to have a category attribute
```
## Changes proposed in this pull request:
* Created a categories controller and model
* Created serializer 
* Created associations between articles and categories
* Created a show method for the categories controller
* Created enum for labels with category names
* Created a FactoryBot
## What I have learned working on this feature:
* How to work with categories and associations 
* How to work with enums
* How to use serializers
