### PR TITLE
Journalist has to be logged in to create an article

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.7'
 gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
+gem 'devise_token_auth'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    bcrypt (3.1.16)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -76,6 +77,16 @@ GEM
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
     crass (1.0.6)
+    devise (4.7.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise_token_auth (1.1.3)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.1)
     diff-lcs (1.4.4)
     docile (1.3.2)
     erubi (1.10.0)
@@ -110,6 +121,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -155,6 +167,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    responders (3.0.1)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.0)
@@ -199,6 +214,8 @@ GEM
       sync
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -211,6 +228,7 @@ DEPENDENCIES
   active_model_serializers
   bootsnap (>= 1.2)
   coveralls
+  devise_token_auth
   factory_bot_rails
   listen (~> 3.0.5)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,4 +1,7 @@
 class Api::ArticlesController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
+  before_action :is_user_journalist?, only: [:create]
+
   def index
     articles = Article.all
     render json: articles, each_serializer: ArticlesIndexSerializer
@@ -12,7 +15,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def create
-    article = Article.create(article_params)
+    article = current_user.articles.create(article_params)
     if article.persisted?
       render json: { message: 'Your article was successfully created!' }, status: 201
     else
@@ -24,5 +27,11 @@ class Api::ArticlesController < ApplicationController
 
   def article_params
     params.require(:article).permit(:title, :lead, :body, :category_id)
+  end
+
+  def is_user_journalist?
+    unless current_user.journalist?
+      render json: { message: 'You are not authorized to create an article.' }, status: 401
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::API
-        include DeviseTokenAuth::Concerns::SetUserByToken
+  include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,5 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :lead, :body
   belongs_to :category
+  belongs_to :author, class_name: 'User'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  extend Devise::Models
+
+  after_initialize :set_default_role, if: :new_record?
+
+  enum role: %i[registered_user journalist]
+
+  has_many :articles, foreign_key: 'author_id'
+
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  include DeviseTokenAuth::Concerns::User
+
+  private
+
+  def set_default_role
+    self.role ||= :registered_user
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class User < ActiveRecord::Base
   extend Devise::Models
 

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = true
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -24,7 +24,7 @@ DeviseTokenAuth.setup do |config|
   # time. In this case, each request in the batch will need to share the same
   # auth token. This setting determines how far apart the requests can be while
   # still using the same auth token.
-  # config.batch_request_buffer_throttle = 5.seconds
+  config.batch_request_buffer_throttle = 5.seconds
 
   # This route will be the prefix for all oauth2 redirect callbacks. For
   # example, using the default '/omniauth', the github oauth2 provider will

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  # config.change_headers_on_each_request = true
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  # config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {:'access-token' => 'access-token',
+  #                        :'client' => 'client',
+  #                        :'expiry' => 'expiry',
+  #                        :'uid' => 'uid',
+  #                        :'token-type' => 'token-type' }
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount_devise_token_auth_for 'User', at: 'api/auth', skip: [:omniauth_callbacks]
   namespace :api do
     resources :articles, only: [:index, :show, :create]
     resources :categories, only: [:show]

--- a/db/migrate/20210109185511_devise_token_auth_create_users.rb
+++ b/db/migrate/20210109185511_devise_token_auth_create_users.rb
@@ -1,0 +1,52 @@
+class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table(:users) do |t|
+      ## Required
+      t.string :provider, null: false, default: 'email'
+      t.string :uid, null: false, default: ''
+
+      ## Database authenticatable
+      t.string :encrypted_password, null: false, default: ''
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.boolean  :allow_password_change, default: false
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+      ## User Info
+      t.string :email
+
+      ## Login Info
+      t.integer :sign_in_count, default: 0
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+
+      ## Tokens
+      t.json :tokens
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, %i[uid provider], unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,       unique: true
+  end
+end

--- a/db/migrate/20210109190413_add_role_to_users.rb
+++ b/db/migrate/20210109190413_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer
+  end
+end

--- a/db/migrate/20210109192420_add_author_id_on_article.rb
+++ b/db/migrate/20210109192420_add_author_id_on_article.rb
@@ -1,0 +1,5 @@
+class AddAuthorIdOnArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :author_id, :integer, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_090655) do
+ActiveRecord::Schema.define(version: 2021_01_09_190413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_090655) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
-    t.integer "label"
-    t.bigint "category_id"
+    t.bigint "category_id", null: false
     t.index ["category_id"], name: "index_articles_on_category_id"
   end
 
@@ -30,6 +29,34 @@ ActiveRecord::Schema.define(version: 2021_01_08_090655) do
     t.string "label"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "email"
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "role"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "articles", "categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_09_190413) do
+ActiveRecord::Schema.define(version: 2021_01_09_192420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2021_01_09_190413) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
     t.bigint "category_id", null: false
+    t.integer "author_id", null: false
     t.index ["category_id"], name: "index_articles_on_category_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     lead { "MyLead" }
     body { "MyBody" }
     association :category
+    association :author, factory: :journalist
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { "user@test.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,13 @@
 FactoryBot.define do
   factory :user do
-    email { "user@test.com" }
-    password { "password" }
-    password_confirmation { "password" }
+    email { 'user@test.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    factory :registered_user do
+      role { :registered_user }
+    end
+    factory :journalist do
+      role { :journalist }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     end
     factory :journalist do
       role { :journalist }
+      email { 'journalist@test.com' }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe User, type: :model do
+  it 'is expected to have valid Factory' do
+    expect(create(:user)).to be_valid
+    expect(create(:registered_user, email: 'registered@example.com')).to be_valid
+    expect(create(:journalist, email: 'journalist@example.com')).to be_valid
+  end
+  describe 'Database table' do
+    it { is_expected.to have_db_column :encrypted_password }
+    it { is_expected.to have_db_column :email }
+    it { is_expected.to have_db_column :tokens }
+    it { is_expected.to have_db_column :name }
+  end
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_confirmation_of :password }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :tokens }
-    it { is_expected.to have_db_column :name }
   end
   describe 'Validations' do
     it { is_expected.to validate_presence_of :email }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,15 +1,21 @@
 RSpec.describe User, type: :model do
-  it 'is expected to have valid Factory' do
-    expect(create(:user)).to be_valid
-    expect(create(:registered_user, email: 'registered@example.com')).to be_valid
-    expect(create(:journalist, email: 'journalist@example.com')).to be_valid
+  describe 'Factory Bot' do
+    it 'is expected to have a valid user factory bot' do
+      expect(create(:user)).to be_valid
+    end
+    it 'is expected to have a valid registered_user factory bot' do
+      expect(create(:registered_user, email: 'registered@example.com')).to be_valid
+    end
+    it 'is expected to have a valid journalist factory bot' do
+      expect(create(:journalist, email: 'journalist@example.com')).to be_valid
+    end
   end
-  describe 'Database table' do
+  describe 'is expected to have db colums' do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :tokens }
   end
-  describe 'Validations' do
+  describe 'is expected to have validation' do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_confirmation_of :password }
   end

--- a/spec/requests/api/journalist_can_create_an_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_an_article_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'POST/api/articles', type: :request do
       expect(response).to have_http_status 401
     end
     it 'is expected to return an error message' do
-      expect(response_json['errors']).to eq ['You need to sign in or sign up before continuing.']
+      expect(response_json).to have_key('errors').and have_value(['You need to sign in or sign up before continuing.'])
     end
   end
 end

--- a/spec/requests/api/journalist_can_create_an_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_an_article_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'POST/api/articles', type: :request do
-  let(:registered_user) { create(:user, role: 'registered_user') }
+  let(:registered_user) { create(:registered_user) }
   let(:registered_user_headers) { registered_user.create_new_auth_token }
-  let(:journalist) { create(:user, role: 'journalist') }
+  let(:journalist) { create(:journalist) }
   let(:journalist_headers) { journalist.create_new_auth_token }
   let(:category) { create(:category, label: 'global_politics') }
 

--- a/spec/requests/api/visitor_can_see_list_of_articles_spec.rb
+++ b/spec/requests/api/visitor_can_see_list_of_articles_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'GET/api/articles' do
     before do
       get '/api/articles'
     end
-    it 'expected to return a 200 response' do
+    it 'is expected to return a 200 response' do
       expect(response).to have_http_status 200
     end
 
@@ -21,7 +21,7 @@ RSpec.describe 'GET/api/articles' do
       expect(response_json['articles'][2]['created']).to eq Date.today.strftime('%F')
     end
 
-    it 'expected to return all articles' do
+    it 'is expected to return all articles' do
       expect(response_json['articles'].count).to eq 3
     end
   end

--- a/spec/requests/api/visitor_can_see_list_of_articles_spec.rb
+++ b/spec/requests/api/visitor_can_see_list_of_articles_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'GET/api/articles' do
-  let!(:articles) { 3.times { create(:article) } }
+  let(:journalist) { create(:journalist, email: 'journalist2@email.com')}
+  let!(:articles) { 3.times { create(:article, author_id: journalist.id) } }
   describe 'successfully get list of articles' do
     before do
       get '/api/articles'

--- a/spec/requests/api/visitor_can_see_specific_article_spec.rb
+++ b/spec/requests/api/visitor_can_see_specific_article_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'GET/api/atricles' do
       get "/api/articles/#{article.id}"
     end
 
-    it 'expected to return a 200 response' do
+    it 'is expected to return a 200 response' do
       expect(response).to have_http_status 200
     end
 
@@ -22,7 +22,7 @@ RSpec.describe 'GET/api/atricles' do
         get '/api/articles/abc'
       end
 
-      it 'expected to return a 404 response' do
+      it 'is expected to return a 404 response' do
         expect(response).to have_http_status 404
       end
 

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'GET/api/categories' do
       expect(response_json['category']['articles'].count).to eq 2
     end
 
-    it 'it expected to return the label of the category' do
+    it 'is expected to return the label of the category' do
       expect(response_json['category']['label']).to eq 'global_politics'
     end
 
@@ -30,7 +30,7 @@ RSpec.describe 'GET/api/categories' do
         get '/api/categories/abc'
       end
 
-      it 'expected to return a 404 response' do
+      it 'is expected to return a 404 response' do
         expect(response).to have_http_status 404
       end
 

--- a/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
+++ b/spec/requests/api/visitor_can_view_articles_by_categories_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe 'GET/api/categories' do
-  let!(:category) { create(:category, label: 'global_politics') }
-  let!(:articles) { 2.times { create(:article, category: category) } }
+  let(:category) { create(:category, label: 'global_politics') }
+  let(:journalist) { create(:journalist, email: 'journalist2@email.com')}
+  let!(:articles)  { create(:article, category: category) } 
+  let!(:articles2) { create(:article, category: category, author_id: journalist.id ) } 
 
   describe 'successfully get articles sorted into categories' do
     before do


### PR DESCRIPTION
[Journalist has to be logged in to create an article](https://www.pivotaltracker.com/story/show/176339828)
## User Story
```
As an API,
In order to keep the content secure,
I would like to be able to have the journalists to log in before creating articles
```

## Changes proposed in this pull request:
* Adding User model with devise_token_auth
* Creating a test and factory bot for User model
* Adding role to User model using enum
* Creating authentication and authorization for create action in article controller
* Creating a test to check if only journalist can create an article
* Adding a route to create articles

## What I have learned working on this feature:
* The importance of running all tests to see if the new implementation breaks something
* How to test for enums

## Packages/Gems added
* devise_token_auth